### PR TITLE
feat: Fetch and render document in the edit page

### DIFF
--- a/src/components/DocEditHeader.jsx
+++ b/src/components/DocEditHeader.jsx
@@ -1,6 +1,5 @@
 import '../styles/header.css'
 import { Link } from 'react-router-dom';
-import { FaBars } from 'react-icons/fa';
 import {handleChangeOnTitle} from "../listeners/document-listeners.js";
 import React from "react";
 
@@ -14,14 +13,13 @@ import React from "react";
 export const DocEditHeader = ({ title, setTitle } ) => {
     return (
         <header>
-            {/* <button><FaBars className={"fa-bars"}/></button> */}
-            <input maxLength={60} id={'title'} value={title}
+            <input maxLength={50} id={'title'} value={title}
                    onChange={handleChangeOnTitle(setTitle)}>
             </input>
-            <Link to="/dashboard" style={{ textDecoration: 'none', color: 'inherit' }}>
+            <Link to='/dashboard' style={{ textDecoration: 'none', color: 'inherit' }}>
               {/* Link to the dashboard so when the logo is clicked it takes the user to the dashboard */}
-        <h1>NexJot</h1>
-      </Link>              
+                <h1>NexJot</h1>
+            </Link>
       </header>
     )
 }

--- a/src/services/document-service.js
+++ b/src/services/document-service.js
@@ -1,4 +1,17 @@
 
+export const getDocument = async (id) => {
+    try {
+        const response = await fetch('http://localhost:8080/api/documents/' + id,
+            {'credentials': 'include'});
+        if (response.ok) {
+            return await response.json();
+        } else {
+            return null;
+        }
+    } catch {
+        console.log(`Error retrieving document: ${err}`);
+    }
+}
 
 export const getDocumentsPreview = async (useStaticData=false) => {
     if (useStaticData) {


### PR DESCRIPTION
## What?
Loads the document from the database and render it on the edit page when accessed.

## Why?
To ensure that the user has up-to-date data during editing.

## How?
- Make an API call to fetch the document when the page is rendered.
- Store the fetched document in the state `documents` for usage in the DOM.